### PR TITLE
gemspec: Drop executables directives

### DIFF
--- a/getoptlong.gemspec
+++ b/getoptlong.gemspec
@@ -26,7 +26,5 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z 2>/dev/null`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This gem exposes 0 executables.